### PR TITLE
Add launch with Diploi button to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Deploy your own instance with one click:
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fakshitkrnagpal%2Fopen-placeholder)
 
+### Deploy to Diploi 
+
+Launch Open Placeholder on Diploi in one click and get a live instance running in seconds.
+
+[![launch with diploi button](https://diploi.com/launch-big.svg)](https://diploi.com/launch/akshitkrnagpal/open-placeholder)
+
+Learn more on [Diploi](https://diploi.com/).
+
 ### Self-Hosting
 
 1. Clone the repository:


### PR DESCRIPTION
This pull request introduces a “Launch with Diploi” button to the repository.
This adds a deployment platform as an option for developers to quickly spin up the project with minimal setup and improving overall ease of use.

Further Diploi information can be found from [Diploi](https://diploi.com/)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/open-placeholder/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->