### PR TITLE
feat: add aspect-ratio shortcut routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,28 @@ Display custom text instead of dimensions:
 https://openplaceholder.com/600x300/Hello%20World
 ```
 
+### Shortcut Sizes
+
+Use common aspect-ratio shortcuts without typing dimensions:
+```
+https://openplaceholder.com/og/Product%20Launch
+https://openplaceholder.com/banner/Hero%20Banner
+https://openplaceholder.com/wide/Video%20Thumbnail
+```
+
+| Shortcut | Dimensions | Common use |
+|----------|------------|------------|
+| `og` | 1200x630 | Open Graph/social preview images |
+| `banner` | 1200x400 | Hero and page banners |
+| `wide` | 1600x900 | 16:9 thumbnails and previews |
+
 ## 📖 API Reference
 
 ### URL Format
 
 ```
 https://openplaceholder.com/[width]x[height]/[text]
+https://openplaceholder.com/[shortcut]/[text]
 ```
 
 ### Parameters
@@ -68,6 +84,7 @@ https://openplaceholder.com/[width]x[height]/[text]
 |-----------|------|-------------|---------|
 | `width` | number | Image width in pixels (1-4000) | `600` |
 | `height` | number | Image height in pixels (1-4000) | `400` |
+| `shortcut` | string | Optional preset size (`og`, `banner`, `wide`) | `og` |
 | `text` | string | Optional custom text (URL encoded) | `Hello%20World` |
 
 ### Examples
@@ -90,6 +107,11 @@ https://openplaceholder.com/[width]x[height]/[text]
 #### Banner with Text
 ```html
 <img src="https://openplaceholder.com/1200x400/Hero%20Banner" alt="Hero Banner">
+```
+
+#### Shortcut Size
+```html
+<img src="https://openplaceholder.com/og/Product%20Launch" alt="Product Launch">
 ```
 
 ## 🛠️ Built With

--- a/utils/parser.ts
+++ b/utils/parser.ts
@@ -11,11 +11,17 @@ export interface PlaceholderOptions {
   text?: string;
 }
 
+const shortcuts: Record<string, Pick<PlaceholderOptions, 'width' | 'height'>> = {
+  og: { width: 1200, height: 630 },
+  banner: { width: 1200, height: 400 },
+  wide: { width: 1600, height: 900 },
+};
+
 export const getPlaceholdOptions = (filename: string): PlaceholderOptions | null => {
   try {
     // Check if there's custom text after a slash
     const parts = filename.split('/');
-    let dimensions = parts[0];
+    const dimensions = parts[0];
     let customText: string | undefined;
     
     if (parts.length > 1) {
@@ -23,7 +29,16 @@ export const getPlaceholdOptions = (filename: string): PlaceholderOptions | null
       customText = decodeURIComponent(parts.slice(1).join('/'));
     }
     
-    // Parse dimensions (support both 600x400 and 600 formats)
+    // Parse shortcuts or dimensions (support both 600x400 and 600 formats)
+    const shortcut = shortcuts[dimensions];
+
+    if (shortcut) {
+      return {
+        ...shortcut,
+        text: customText,
+      };
+    }
+
     const [width, height] = dimensions.split('x');
     
     // Return null if width is not a valid number


### PR DESCRIPTION
## Summary
- Add shortcut parsing for /og, /banner, and /wide routes
- Preserve existing dimension and square route parsing
- Document shortcut routes and dimensions in the README

Closes #17

## Test Plan
- pnpm build
- pnpm dev --hostname 127.0.0.1 --port 3100, then curl /og/Product%20Launch, /600x400/Text, and /256 to verify 200 image/png responses and dimensions
- pnpm lint (fails: existing script uses `next lint`, which Next 16 treats as an invalid project directory)
- pnpm exec tsc --noEmit (fails: existing utils/data.ts RequestInit typing rejects the Next-specific `next` fetch option outside Next build)