### PR TITLE
feat: add pattern backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Open Placeholder is a high-performance placeholder image generator built with Ne
 - 🚀 **Edge Runtime** - Lightning-fast image generation at the edge
 - 📐 **Flexible Sizing** - Support for any dimensions up to 4000x4000 pixels
 - 📝 **Custom Text** - Display custom text instead of dimensions
+- 🧩 **Pattern Backgrounds** - Optional grid, dots, and stripes patterns
 - 💾 **Smart Caching** - Optimized with CDN cache headers for performance
 - 🎨 **Clean Design** - Minimalist aesthetic with Geist font
 - 🔧 **Zero Configuration** - Works out of the box with sensible defaults
@@ -54,6 +55,15 @@ Display custom text instead of dimensions:
 https://openplaceholder.com/600x300/Hello%20World
 ```
 
+### Pattern Backgrounds
+
+Add a generated background pattern:
+```
+https://openplaceholder.com/600x300/Hello%20World?pattern=grid
+```
+
+Supported values are `grid`, `dots`, `stripes`, and `none`. The default is `none`.
+
 ## 📖 API Reference
 
 ### URL Format
@@ -69,6 +79,7 @@ https://openplaceholder.com/[width]x[height]/[text]
 | `width` | number | Image width in pixels (1-4000) | `600` |
 | `height` | number | Image height in pixels (1-4000) | `400` |
 | `text` | string | Optional custom text (URL encoded) | `Hello%20World` |
+| `pattern` | query string | Optional background pattern. Defaults to `none`; valid values are `grid`, `dots`, `stripes`, and `none`. | `grid` |
 
 ### Examples
 
@@ -90,6 +101,11 @@ https://openplaceholder.com/[width]x[height]/[text]
 #### Banner with Text
 ```html
 <img src="https://openplaceholder.com/1200x400/Hero%20Banner" alt="Hero Banner">
+```
+
+#### Pattern Background
+```html
+<img src="https://openplaceholder.com/600x300/Hello%20World?pattern=dots" alt="Pattern placeholder">
 ```
 
 ## 🛠️ Built With

--- a/app/[...filename]/route.tsx
+++ b/app/[...filename]/route.tsx
@@ -1,9 +1,17 @@
 import { getPlaceholdOptions } from '@/utils/parser';
 import { ImageResponse } from 'next/og';
+import type { CSSProperties } from 'react';
 
 type Params = Promise<{
   filename: string[];
 }>;
+
+type Pattern = 'grid' | 'dots' | 'stripes' | 'none';
+
+const patterns = new Set<Pattern>(['grid', 'dots', 'stripes', 'none']);
+const backgroundColor = '#EEE';
+const foregroundColor = '#31343C';
+const patternColor = 'rgba(49, 52, 60, 0.12)';
 
 export const runtime = 'edge';
 
@@ -19,7 +27,57 @@ async function getFontData(): Promise<ArrayBuffer> {
   return fontCache as ArrayBuffer;
 }
 
-export async function GET(_request: Request, { params }: { params: Params }) {
+function getPattern(request: Request): Pattern {
+  const pattern = new URL(request.url).searchParams.get('pattern');
+  return patterns.has(pattern as Pattern) ? (pattern as Pattern) : 'none';
+}
+
+function getPatternStyle(pattern: Pattern): CSSProperties {
+  switch (pattern) {
+    case 'grid':
+      return {
+        backgroundImage: `linear-gradient(${patternColor} 1px, transparent 1px), linear-gradient(90deg, ${patternColor} 1px, transparent 1px)`,
+        backgroundSize: '40px 40px',
+      };
+    case 'dots':
+      return {};
+    case 'stripes':
+      return {
+        backgroundImage: `linear-gradient(135deg, ${patternColor} 12.5%, transparent 12.5%, transparent 50%, ${patternColor} 50%, ${patternColor} 62.5%, transparent 62.5%, transparent 100%)`,
+        backgroundSize: '32px 32px',
+      };
+    case 'none':
+    default:
+      return {};
+  }
+}
+
+function renderPatternLayer(pattern: Pattern, width: number, height: number) {
+  if (pattern !== 'dots') {
+    return null;
+  }
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      style={{
+        position: 'absolute',
+        inset: 0,
+      }}
+    >
+      <defs>
+        <pattern id='dots' width='40' height='40' patternUnits='userSpaceOnUse'>
+          <circle cx='20' cy='20' r='1.5' fill={patternColor} />
+        </pattern>
+      </defs>
+      <rect width={width} height={height} fill='url(#dots)' />
+    </svg>
+  );
+}
+
+export async function GET(request: Request, { params }: { params: Params }) {
   const { filename } = await params;
   // Join the array segments back into a single string
   const fullPath = filename.join('/');
@@ -38,6 +96,7 @@ export async function GET(_request: Request, { params }: { params: Params }) {
   const textLength = displayText.length;
   const fontSizeMultiplier = textLength > 20 ? 0.6 : textLength > 10 ? 0.8 : 1;
   const fontSize = baseFontSize * fontSizeMultiplier;
+  const pattern = getPattern(request);
   
   // Use cached font data
   const fontData = await getFontData();
@@ -51,11 +110,15 @@ export async function GET(_request: Request, { params }: { params: Params }) {
           justifyContent: 'center',
           width: '100%',
           height: '100%',
-          backgroundColor: '#EEE',
-          color: '#31343C',
+          backgroundColor,
+          color: foregroundColor,
           padding: '20px',
+          position: 'relative',
+          overflow: 'hidden',
+          ...getPatternStyle(pattern),
         }}
       >
+        {renderPatternLayer(pattern, options.width, options.height)}
         <h1 
           style={{ 
             fontSize, 
@@ -63,6 +126,7 @@ export async function GET(_request: Request, { params }: { params: Params }) {
             textAlign: 'center',
             wordBreak: 'break-word',
             margin: 0,
+            position: 'relative',
           }}
         >
           {displayText}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,11 @@ export default async function Home() {
       url: '/1200x400/Coming%20Soon',
       description: 'Perfect for hero sections',
     },
+    {
+      title: 'Pattern Background',
+      url: '/600x300/Polished?pattern=grid',
+      description: 'Add grid, dots, or stripes with ?pattern=',
+    },
   ];
 
   return (
@@ -87,6 +92,18 @@ export default async function Home() {
                 Add custom text after dimensions (URL encode special characters)
               </p>
             </div>
+
+            <div className='bg-gray-800 rounded p-4'>
+              <h3 className='text-lg font-semibold text-white mb-2'>
+                Pattern Backgrounds
+              </h3>
+              <code className='text-green-400 bg-gray-950 px-2 py-1 rounded'>
+                https://openplaceholder.com/[width]x[height]?pattern=grid
+              </code>
+              <p className='text-gray-400 mt-2'>
+                Use grid, dots, stripes, or none. None is the default.
+              </p>
+            </div>
           </div>
         </div>
 
@@ -133,6 +150,10 @@ export default async function Home() {
             <li className='flex items-start'>
               <span className='text-green-400 mr-2'>✓</span>
               <span>Custom text support with automatic font sizing</span>
+            </li>
+            <li className='flex items-start'>
+              <span className='text-green-400 mr-2'>✓</span>
+              <span>Optional grid, dots, and stripes pattern backgrounds</span>
             </li>
             <li className='flex items-start'>
               <span className='text-green-400 mr-2'>✓</span>


### PR DESCRIPTION
## Summary
- Adds `?pattern=grid|dots|stripes|none` support for generated placeholders.
- Keeps `none` as the default/current background.
- Documents pattern usage and adds a homepage example.

Closes #16

## Test Plan
- `pnpm install --frozen-lockfile`
- `pnpm build` passed.
- Runtime smoke checks against `pnpm start`: `none`, `grid`, `dots`, `stripes`, and invalid pattern URLs returned `200 image/png`; invalid pattern matched the default `none` output.
- `pnpm lint` has an existing baseline script issue: `next lint` is no longer valid here and exits with `Invalid project directory provided .../lint` on a clean baseline too.
- `pnpm exec tsc --noEmit` has an existing baseline failure in `utils/data.ts` (`next` is not assignable to `RequestInit`).

## Notes
- Independent pre-commit review found no blocking security or logic issues.
