### PR TITLE
feat: add banner layout presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Display custom text instead of dimensions:
 https://openplaceholder.com/600x300/Hello%20World
 ```
 
+### Layout Presets
+
+Use `layout` for common banner compositions. The default layout is unchanged when this parameter is omitted.
+```
+https://openplaceholder.com/1200x630/Product%20Launch?layout=hero
+https://openplaceholder.com/800x400/New%20Feature?layout=badge
+https://openplaceholder.com/1200x600/Case%20Study?layout=split
+https://openplaceholder.com/900x1200/Event%20Poster?layout=poster
+```
+
 ## 📖 API Reference
 
 ### URL Format
@@ -69,6 +79,7 @@ https://openplaceholder.com/[width]x[height]/[text]
 | `width` | number | Image width in pixels (1-4000) | `600` |
 | `height` | number | Image height in pixels (1-4000) | `400` |
 | `text` | string | Optional custom text (URL encoded) | `Hello%20World` |
+| `layout` | query string | Optional preset: `hero`, `badge`, `split`, or `poster` | `?layout=hero` |
 
 ### Examples
 
@@ -89,7 +100,22 @@ https://openplaceholder.com/[width]x[height]/[text]
 
 #### Banner with Text
 ```html
-<img src="https://openplaceholder.com/1200x400/Hero%20Banner" alt="Hero Banner">
+<img src="https://openplaceholder.com/1200x400/Hero%20Banner?layout=hero" alt="Hero Banner">
+```
+
+#### Badge Layout
+```html
+<img src="https://openplaceholder.com/800x400/Stable?layout=badge" alt="Stable badge">
+```
+
+#### Split Layout
+```html
+<img src="https://openplaceholder.com/1200x600/Case%20Study?layout=split" alt="Case Study">
+```
+
+#### Poster Layout
+```html
+<img src="https://openplaceholder.com/900x1200/Event%20Poster?layout=poster" alt="Event Poster">
 ```
 
 ## 🛠️ Built With

--- a/app/[...filename]/route.tsx
+++ b/app/[...filename]/route.tsx
@@ -1,4 +1,4 @@
-import { getPlaceholdOptions } from '@/utils/parser';
+import { getPlaceholdOptions, type PlaceholderLayout } from '@/utils/parser';
 import { ImageResponse } from 'next/og';
 
 type Params = Promise<{
@@ -19,11 +19,186 @@ async function getFontData(): Promise<ArrayBuffer> {
   return fontCache as ArrayBuffer;
 }
 
-export async function GET(_request: Request, { params }: { params: Params }) {
+function renderPlaceholder({
+  layout,
+  displayText,
+  dimensionsText,
+  fontSize,
+}: {
+  layout?: PlaceholderLayout;
+  displayText: string;
+  dimensionsText: string;
+  fontSize: number;
+}) {
+  const textStyles = {
+    fontFamily: 'Geist',
+    wordBreak: 'break-word' as const,
+    margin: 0,
+  };
+
+  switch (layout) {
+    case 'hero':
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+            position: 'relative',
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#111827',
+            color: '#FFFFFF',
+            padding: '56px',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              right: '-12%',
+              top: '-25%',
+              width: '50%',
+              height: '150%',
+              backgroundColor: '#374151',
+              transform: 'rotate(12deg)',
+            }}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '20px', maxWidth: '70%' }}>
+            <div style={{ display: 'flex', fontSize: Math.max(fontSize * 0.22, 18), opacity: 0.72 }}>
+              {dimensionsText}
+            </div>
+            <h1 style={{ ...textStyles, fontSize, lineHeight: 1.05 }}>{displayText}</h1>
+          </div>
+        </div>
+      );
+    case 'badge':
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#F8FAFC',
+            color: '#111827',
+            padding: '32px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: '18px',
+              padding: '28px 48px',
+              border: '6px solid #111827',
+              borderRadius: '9999px',
+              backgroundColor: '#FFFFFF',
+            }}
+          >
+            <h1 style={{ ...textStyles, fontSize: fontSize * 0.74, textAlign: 'center' }}>{displayText}</h1>
+            <div style={{ display: 'flex', fontSize: Math.max(fontSize * 0.18, 14), color: '#6B7280' }}>
+              {dimensionsText}
+            </div>
+          </div>
+        </div>
+      );
+    case 'split':
+      return (
+        <div style={{ display: 'flex', width: '100%', height: '100%', backgroundColor: '#E5E7EB' }}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              width: '58%',
+              height: '100%',
+              backgroundColor: '#31343C',
+              color: '#FFFFFF',
+              padding: '48px',
+            }}
+          >
+            <h1 style={{ ...textStyles, fontSize: fontSize * 0.82, lineHeight: 1.1 }}>{displayText}</h1>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '42%',
+              height: '100%',
+              color: '#31343C',
+              padding: '32px',
+            }}
+          >
+            <div style={{ display: 'flex', fontSize: Math.max(fontSize * 0.3, 18), textAlign: 'center' }}>
+              {dimensionsText}
+            </div>
+          </div>
+        </div>
+      );
+    case 'poster':
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#F3F4F6',
+            color: '#111827',
+            padding: '44px',
+          }}
+        >
+          <div style={{ display: 'flex', width: '100%', height: '12px', backgroundColor: '#111827' }} />
+          <h1 style={{ ...textStyles, fontSize: fontSize * 0.9, lineHeight: 1.05, textAlign: 'center' }}>
+            {displayText}
+          </h1>
+          <div style={{ display: 'flex', fontSize: Math.max(fontSize * 0.22, 16), color: '#6B7280' }}>
+            {dimensionsText}
+          </div>
+        </div>
+      );
+    default:
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#EEE',
+            color: '#31343C',
+            padding: '20px',
+          }}
+        >
+          <h1
+            style={{
+              fontSize,
+              fontFamily: 'Geist',
+              textAlign: 'center',
+              wordBreak: 'break-word',
+              margin: 0,
+            }}
+          >
+            {displayText}
+          </h1>
+        </div>
+      );
+  }
+}
+
+export async function GET(request: Request, { params }: { params: Params }) {
   const { filename } = await params;
   // Join the array segments back into a single string
   const fullPath = filename.join('/');
-  const options = getPlaceholdOptions(fullPath);
+  const layout = new URL(request.url).searchParams.get('layout');
+  const options = getPlaceholdOptions(fullPath, layout);
   
   // Return 404 if the URL is invalid
   if (!options) {
@@ -38,37 +213,18 @@ export async function GET(_request: Request, { params }: { params: Params }) {
   const textLength = displayText.length;
   const fontSizeMultiplier = textLength > 20 ? 0.6 : textLength > 10 ? 0.8 : 1;
   const fontSize = baseFontSize * fontSizeMultiplier;
+  const dimensionsText = `${options.width} x ${options.height}`;
   
   // Use cached font data
   const fontData = await getFontData();
   
   return new ImageResponse(
-    (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: '100%',
-          height: '100%',
-          backgroundColor: '#EEE',
-          color: '#31343C',
-          padding: '20px',
-        }}
-      >
-        <h1 
-          style={{ 
-            fontSize, 
-            fontFamily: 'Geist',
-            textAlign: 'center',
-            wordBreak: 'break-word',
-            margin: 0,
-          }}
-        >
-          {displayText}
-        </h1>
-      </div>
-    ),
+    renderPlaceholder({
+      layout: options.layout,
+      displayText,
+      dimensionsText,
+      fontSize,
+    }),
     {
       width: options.width,
       height: options.height,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/utils/parser.ts
+++ b/utils/parser.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+const layoutSchema = z.enum(['hero', 'badge', 'split', 'poster']);
+
+export type PlaceholderLayout = z.infer<typeof layoutSchema>;
+
 const optionsSchema = z.object({
   width: z.coerce.number().positive().min(1).max(4000),
   height: z.coerce.number().positive().min(1).max(4000),
@@ -9,9 +13,13 @@ export interface PlaceholderOptions {
   width: number;
   height: number;
   text?: string;
+  layout?: PlaceholderLayout;
 }
 
-export const getPlaceholdOptions = (filename: string): PlaceholderOptions | null => {
+export const getPlaceholdOptions = (
+  filename: string,
+  layout?: string | null
+): PlaceholderOptions | null => {
   try {
     // Check if there's custom text after a slash
     const parts = filename.split('/');
@@ -36,9 +44,12 @@ export const getPlaceholdOptions = (filename: string): PlaceholderOptions | null
       height: height ?? width 
     });
     
+    const parsedLayout = layoutSchema.safeParse(layout);
+
     return {
       ...parsedOptions,
       text: customText,
+      layout: parsedLayout.success ? parsedLayout.data : undefined,
     };
   } catch (error) {
     // Return null for any parsing errors


### PR DESCRIPTION
## Summary
- Adds `?layout=hero|badge|split|poster` parsing for placeholder images.
- Renders each preset with Vercel OG-compatible flex/absolute styles while leaving the default layout unchanged.
- Documents the new banner layout examples in the README.

Closes #15

## Test Plan
- `pnpm build`
- `pnpm lint` (fails: existing `next lint` script is incompatible with Next 16 and treats `lint` as a project directory)
- Manual curl smoke test for default, hero, badge, split, and poster layouts returned 200 image/png
