### PR TITLE
fix: pin pnpm package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "open-placeholder",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.24.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- Add packageManager metadata so Corepack resolves pnpm 10.24.0 instead of latest pnpm.
- Keeps Docker/Node 20 builds from picking pnpm 11, which requires newer Node built-ins such as node:sqlite.

## Test plan
- CI=true npm exec --yes pnpm@10.24.0 -- install --frozen-lockfile
- npm exec --yes pnpm@10.24.0 -- run build

Related investigation: PR #7 Vercel is still blocked by team authorization, but this fixes the repo-side Docker/Corepack failure found while reproducing it.