### PR TITLE
fix: route reserved placeholder paths

### DIFF
--- a/app/404/route.tsx
+++ b/app/404/route.tsx
@@ -1,0 +1,9 @@
+import { GET as handlePlaceholder } from '../[...filename]/route';
+
+export const runtime = 'edge';
+
+export function GET(request: Request) {
+  return handlePlaceholder(request, {
+    params: Promise.resolve({ filename: ['404'] }),
+  });
+}

--- a/app/500/route.tsx
+++ b/app/500/route.tsx
@@ -1,0 +1,9 @@
+import { GET as handlePlaceholder } from '../[...filename]/route';
+
+export const runtime = 'edge';
+
+export function GET(request: Request) {
+  return handlePlaceholder(request, {
+    params: Promise.resolve({ filename: ['500'] }),
+  });
+}


### PR DESCRIPTION
## Summary
- Add explicit `/404` and `/500` route handlers so production builds do not treat those placeholder sizes as framework error pages.
- Delegate both reserved routes to the existing catch-all placeholder generator.

Fixes #1

## Test plan
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm exec next start -p 3001` and verified `/404`, `/500`, `/512`, and `/600x400` all return `200 image/png`

## Notes
- `pnpm lint` currently fails before linting because `next lint` is no longer a valid Next 16 CLI command in this repo: `Invalid project directory provided, no such directory: .../lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated error pages for 404 (Not Found) and 500 (Server Error) responses, optimized for edge performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akshitkrnagpal/open-placeholder/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->